### PR TITLE
Update readme - org.apache.cordova.geolocation has been renamed

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ http://ionic-leafletjs-map-demo.divshot.io/#/app/map
 ```sh
 ionic start myMapDemo https://github.com/calendee/ionic-leafletjs-map-demo
 cd myMapDemo
-cordova plugin add org.apache.cordova.geolocation
+cordova plugin add cordova-plugin-geolocation
 ionic platform add ios
 ionic platform add android
 ionic serve


### PR DESCRIPTION
> WARNING: org.apache.cordova.geolocation has been renamed to cordova-plugin-geolocation. You may not be getting the latest version! We suggest you `cordova plugin rm org.apache.cordova.geolocation` and `cordova plugin add cordova-plugin-geolocation`.
